### PR TITLE
543 ami checks

### DIFF
--- a/cmd/tarmak/cmd/cluster_images_list.go
+++ b/cmd/tarmak/cmd/cluster_images_list.go
@@ -25,13 +25,14 @@ var clusterImagesListCmd = &cobra.Command{
 		images, err := t.Packer().List()
 		t.Must(err)
 
-		format := "%s\t%s\t%s\t%s\t%s\n"
+		format := "%s\t%s\t%s\t%v\t%s\t%s\n"
 		fmt.Fprintf(
 			w,
 			format,
 			"Image ID",
 			"Base Image",
 			"Location",
+			"Encrypted",
 			"Tags",
 			"Created",
 		)
@@ -43,6 +44,7 @@ var clusterImagesListCmd = &cobra.Command{
 				image.Name,
 				image.BaseImage,
 				image.Location,
+				image.Encrypted,
 				image.Annotations,
 				image.CreationTimestamp.Format(time.RFC3339),
 			)

--- a/pkg/apis/tarmak/v1alpha1/types.go
+++ b/pkg/apis/tarmak/v1alpha1/types.go
@@ -110,6 +110,7 @@ type Image struct {
 
 	BaseImage string `json:"baseImage,omitempty"`
 	Location  string `json:"location,omitempty"`
+	Encrypted bool   `json:"encrypted,omitempty"`
 }
 
 // This represents tarmaks global flags

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -130,7 +130,6 @@ type Provider interface {
 	AskEnvironmentLocation(Initialize) (string, error)
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
-	VerifyInstanceTypes(instancePools []InstancePool) error
 	EnsureRemoteResources() error
 }
 

--- a/pkg/tarmak/interfaces/interfaces.go
+++ b/pkg/tarmak/interfaces/interfaces.go
@@ -109,7 +109,7 @@ type Provider interface {
 	Name() string
 	Parameters() map[string]string
 	Region() string
-	// Verify the cluster (these contain more expensive calls like AWS calls
+	// Verify the cluster (these contain more expensive calls like AWS calls)
 	Verify() error
 	// Validate the cluster (these contain less expensive local calls)
 	Validate() error
@@ -130,7 +130,7 @@ type Provider interface {
 	AskEnvironmentLocation(Initialize) (string, error)
 	AskInstancePoolZones(Initialize) (zones []string, err error)
 	UploadConfiguration(Cluster, io.ReadSeeker) error
-	VerifyInstanceTypes(intstancePools []InstancePool) error
+	VerifyInstanceTypes(instancePools []InstancePool) error
 	EnsureRemoteResources() error
 }
 

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -36,14 +36,13 @@ type Amazon struct {
 	availabilityZones *[]string
 	remoteStateKMS    string
 
-	session      *session.Session
-	ec2          EC2
-	s3           S3
-	kms          KMS
-	dynamodb     DynamoDB
-	route53      Route53
-	log          *logrus.Entry
-	ebsEncrypted bool
+	session  *session.Session
+	ec2      EC2
+	s3       S3
+	kms      KMS
+	dynamodb DynamoDB
+	route53  Route53
+	log      *logrus.Entry
 }
 
 type S3 interface {

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -8,9 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 
-	//TODO: 459
-	"log"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -26,7 +23,6 @@ import (
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
 	tarmakv1alpha1 "github.com/jetstack/tarmak/pkg/apis/tarmak/v1alpha1"
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
-	"github.com/jetstack/tarmak/pkg/tarmak/utils"
 	"github.com/jetstack/tarmak/pkg/tarmak/utils/input"
 )
 
@@ -370,9 +366,13 @@ func (a *Amazon) Verify() error {
 		result = multierror.Append(result, err)
 	}
 
-	// if err := a.verifyEBSEncrypted(); err != nil {
-	// 	result = multierror.Append(result, err)
-	// }
+	if err := a.verifyInstanceTypes(); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if err := a.verifyEBSEncrypted(); err != nil {
+		result = multierror.Append(result, err)
+	}
 
 	return result.ErrorOrNil()
 }
@@ -572,7 +572,7 @@ func (a *Amazon) vaultSession() (*session.Session, error) {
 	return sess, nil
 }
 
-func (a *Amazon) VerifyInstanceTypes(instancePools []interfaces.InstancePool) error {
+func (a *Amazon) verifyInstanceTypes() error {
 	var result error
 
 	svc, err := a.EC2()
@@ -580,7 +580,7 @@ func (a *Amazon) VerifyInstanceTypes(instancePools []interfaces.InstancePool) er
 		return err
 	}
 
-	for _, instance := range instancePools {
+	for _, instance := range a.tarmak.Cluster().InstancePools() {
 		instanceType, err := a.InstanceType(instance.Config().Size)
 		if err != nil {
 			return err
@@ -665,65 +665,4 @@ func (a *Amazon) VolumeType(typeIn string) (typeOut string, err error) {
 	}
 	// TODO: Validate custom instance type here
 	return typeIn, nil
-}
-
-func (a *Amazon) verifyEBSEncrypted() error {
-
-	var result error
-
-	// TODO: 459 - pass an a.EC2() to this function to lower expense
-	svc, err := a.EC2()
-	if err != nil {
-		return err
-	}
-
-	imageids, err := a.tarmak.Cluster().ImageIDs()
-	if err != nil {
-		return err
-	}
-
-	packerimages, err := a.tarmak.Packer().List()
-	if err != nil {
-		return err
-	}
-
-	log.Println(packerimages)
-
-	// Convert map to slice to conform with AWS SDK ec2.DescribeImagesInput
-	idslice := []string{}
-	for _, imageid := range imageids {
-		idslice = append(idslice, imageid)
-	}
-
-	request := &ec2.DescribeImagesInput{
-		ImageIds: aws.StringSlice(utils.RemoveDuplicateStrings(idslice)),
-	}
-	awsamis, err := svc.DescribeImages(request)
-	if err != nil {
-		return fmt.Errorf("error reaching aws to request image descriptions: %v", err)
-	}
-
-	// THEN VERIFY THAT ENCRYPTED == TRUE  ON AWS AND ENCRYPTED == TRUE ON PACKER
-	//				OR	ENCRYPTED == FALSE ON AWS AND ENCRYPTED == FALSE ON PACKER
-	for key, awsami := range awsamis.Images {
-		tarmakimage := tarmakv1alpha1.Image{}
-		tarmakimage.Annotations = map[string]string{}
-		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted == true {
-			log.Println("Encrypted true")
-		}
-		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted == false {
-			log.Println("Encrypted false")
-		}
-		// if *awsami.BlockDeviceMappings[key].Ebs.Encrypted != a.tarmak.Config().Cluster().ImageIDs() {
-		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted {
-			result = multierror.Append(result, fmt.Errorf("AMI'%s' expected encrypted =%v", *awsami.Name, *awsami.BlockDeviceMappings[key].Ebs.Encrypted))
-		}
-
-		// if == nil or false, result is:
-
-		// AMI id expected to be
-
-	}
-
-	return result
 }

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"sort"
 
+	//TODO: 459
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -36,13 +39,14 @@ type Amazon struct {
 	availabilityZones *[]string
 	remoteStateKMS    string
 
-	session  *session.Session
-	ec2      EC2
-	s3       S3
-	kms      KMS
-	dynamodb DynamoDB
-	route53  Route53
-	log      *logrus.Entry
+	session      *session.Session
+	ec2          EC2
+	s3           S3
+	kms          KMS
+	dynamodb     DynamoDB
+	route53      Route53
+	log          *logrus.Entry
+	ebsEncrypted bool
 }
 
 type S3 interface {
@@ -64,6 +68,7 @@ type EC2 interface {
 	DescribeAvailabilityZones(input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 	DescribeRegions(input *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
 	DescribeReservedInstancesOfferings(input *ec2.DescribeReservedInstancesOfferingsInput) (*ec2.DescribeReservedInstancesOfferingsOutput, error)
+	DescribeImages(input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
 }
 
 type DynamoDB interface {
@@ -358,12 +363,15 @@ func (a *Amazon) Verify() error {
 		if err := a.verifyAvailabilityZones(); err != nil {
 			result = multierror.Append(result, err)
 		}
-
 	}
 
 	if err := a.verifyPublicZone(); err != nil {
 		result = multierror.Append(result, err)
 	}
+
+	// if err := a.verifyEBSEncrypted(); err != nil {
+	// 	result = multierror.Append(result, err)
+	// }
 
 	return result.ErrorOrNil()
 }
@@ -580,6 +588,7 @@ func (a *Amazon) VerifyInstanceTypes(instancePools []interfaces.InstancePool) er
 		if err := a.verifyInstanceType(instanceType, instance.Zones(), svc); err != nil {
 			result = multierror.Append(result, err)
 		}
+
 	}
 
 	return result
@@ -655,4 +664,81 @@ func (a *Amazon) VolumeType(typeIn string) (typeOut string, err error) {
 	}
 	// TODO: Validate custom instance type here
 	return typeIn, nil
+}
+
+func (a *Amazon) verifyEBSEncrypted() error {
+
+	var result error
+	var matching bool
+
+	// TODO: 459 - pass an a.EC2() to this function to lower expense
+	svc, err := a.EC2()
+	if err != nil {
+		return err
+	}
+
+	imageids, err := a.tarmak.Cluster().ImageIDs()
+	if err != nil {
+		return err
+	}
+
+	packerimages, err := a.tarmak.Packer().List()
+	if err != nil {
+		return err
+	}
+
+	log.Println(packerimages)
+
+	// Convert map to slice to conform with AWS SDK ec2.DescribeImagesInput
+	idslice := []string{}
+	for _, imageid := range imageids {
+		idslice = append(idslice, imageid)
+	}
+
+	deduplicatedsliceofids := deduplicate(idslice)
+
+	request := &ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice(deduplicatedsliceofids),
+	}
+	awsamis, err := svc.DescribeImages(request)
+	if err != nil {
+		return fmt.Errorf("error reaching aws to request image descriptions: %v", err)
+	}
+
+	// THEN VERIFY THAT ENCRYPTED == TRUE  ON AWS AND ENCRYPTED == TRUE ON PACKER
+	//				OR	ENCRYPTED == FALSE ON AWS AND ENCRYPTED == FALSE ON PACKER
+	for key, awsami := range awsamis.Images {
+		tarmakimage := tarmakv1alpha1.Image{}
+		tarmakimage.Annotations = map[string]string{}
+		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted == true {
+			log.Println("Encrypted true")
+		}
+		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted == false {
+			log.Println("Encrypted false")
+		}
+		// if *awsami.BlockDeviceMappings[key].Ebs.Encrypted != a.tarmak.Config().Cluster().ImageIDs() {
+		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted {
+			result = multierror.Append(result, fmt.Errorf("AMI ID '%s' expected encrypted =%v"), " ", *awsami.BlockDeviceMappings[key].Ebs.Encrypted)
+
+		}
+
+		// if == nil or false, result is:
+
+		// AMI id expected to be
+
+	}
+
+	return result
+}
+
+func deduplicate(stringSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }

--- a/pkg/tarmak/provider/amazon/amazon.go
+++ b/pkg/tarmak/provider/amazon/amazon.go
@@ -26,6 +26,7 @@ import (
 	clusterv1alpha1 "github.com/jetstack/tarmak/pkg/apis/cluster/v1alpha1"
 	tarmakv1alpha1 "github.com/jetstack/tarmak/pkg/apis/tarmak/v1alpha1"
 	"github.com/jetstack/tarmak/pkg/tarmak/interfaces"
+	"github.com/jetstack/tarmak/pkg/tarmak/utils"
 	"github.com/jetstack/tarmak/pkg/tarmak/utils/input"
 )
 
@@ -669,7 +670,6 @@ func (a *Amazon) VolumeType(typeIn string) (typeOut string, err error) {
 func (a *Amazon) verifyEBSEncrypted() error {
 
 	var result error
-	var matching bool
 
 	// TODO: 459 - pass an a.EC2() to this function to lower expense
 	svc, err := a.EC2()
@@ -695,10 +695,8 @@ func (a *Amazon) verifyEBSEncrypted() error {
 		idslice = append(idslice, imageid)
 	}
 
-	deduplicatedsliceofids := deduplicate(idslice)
-
 	request := &ec2.DescribeImagesInput{
-		ImageIds: aws.StringSlice(deduplicatedsliceofids),
+		ImageIds: aws.StringSlice(utils.RemoveDuplicateStrings(idslice)),
 	}
 	awsamis, err := svc.DescribeImages(request)
 	if err != nil {
@@ -718,8 +716,7 @@ func (a *Amazon) verifyEBSEncrypted() error {
 		}
 		// if *awsami.BlockDeviceMappings[key].Ebs.Encrypted != a.tarmak.Config().Cluster().ImageIDs() {
 		if *awsami.BlockDeviceMappings[key].Ebs.Encrypted {
-			result = multierror.Append(result, fmt.Errorf("AMI ID '%s' expected encrypted =%v"), " ", *awsami.BlockDeviceMappings[key].Ebs.Encrypted)
-
+			result = multierror.Append(result, fmt.Errorf("AMI'%s' expected encrypted =%v", *awsami.Name, *awsami.BlockDeviceMappings[key].Ebs.Encrypted))
 		}
 
 		// if == nil or false, result is:
@@ -729,16 +726,4 @@ func (a *Amazon) verifyEBSEncrypted() error {
 	}
 
 	return result
-}
-
-func deduplicate(stringSlice []string) []string {
-	keys := make(map[string]bool)
-	list := []string{}
-	for _, entry := range stringSlice {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
-		}
-	}
-	return list
 }

--- a/pkg/tarmak/provider/amazon/image.go
+++ b/pkg/tarmak/provider/amazon/image.go
@@ -84,3 +84,20 @@ func (a *Amazon) QueryImages(tags map[string]string) (images []tarmakv1alpha1.Im
 
 	return images, result.ErrorOrNil()
 }
+
+func (a *Amazon) verifyEBSEncrypted() error {
+	images, err := a.tarmak.Packer().List()
+	if err != nil {
+		return err
+	}
+
+	var result *multierror.Error
+	for _, image := range images {
+		if enc := *a.tarmak.Cluster().Config().Amazon.EBSEncrypted; image.Encrypted != enc {
+			err = fmt.Errorf("instance pool image '%s' has encrypted=%t, cluster wide expected=%t", image.Name, image.Encrypted, enc)
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result.ErrorOrNil()
+}

--- a/pkg/tarmak/provider/amazon/image.go
+++ b/pkg/tarmak/provider/amazon/image.go
@@ -68,7 +68,6 @@ func (a *Amazon) QueryImages(tags map[string]string) (images []tarmakv1alpha1.Im
 				image.Encrypted = *d.Ebs.Encrypted
 				foundRoot = true
 				break
-
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovery of AMI id should support a check if the actual AMI is actually encrypted or not

**Which issue this PR fixes**
`fixes #543`

```release-note
Discovery of AMI id supports a check as to whether the actual AMI is encrypted or not
cluster images list displays encrypted flag
```
